### PR TITLE
Server: Use scylla CachingSession

### DIFF
--- a/Server/src/db/scylla_db_operations.rs
+++ b/Server/src/db/scylla_db_operations.rs
@@ -1,20 +1,20 @@
-use scylla::{Session};
-use std::sync::Arc;
-use futures::TryStreamExt;
-use uuid::Uuid;
-use anyhow::{Context, Result};
-use scylla::batch::Batch;
-use scylla::frame::value::Counter;
 use crate::db::paste_db_operations::PasteDbOperations;
 use crate::models::paste::{PasteById, PasteInfoById};
 use crate::models::user::UserById;
+use anyhow::{Context, Result};
+use futures::TryStreamExt;
+use scylla::batch::Batch;
+use scylla::frame::value::Counter;
+use scylla::CachingSession;
+use std::sync::Arc;
+use uuid::Uuid;
 
 pub struct ScyllaDbOperations {
-    session: Arc<Session>,
+    session: Arc<CachingSession>,
 }
 
 impl ScyllaDbOperations {
-    pub fn new(session: Arc<Session>) -> Self {
+    pub fn new(session: Arc<CachingSession>) -> Self {
         Self { session }
     }
 }
@@ -22,8 +22,12 @@ impl ScyllaDbOperations {
 #[async_trait::async_trait]
 impl PasteDbOperations for ScyllaDbOperations {
     async fn get_user_by_id(&self, userid: Uuid) -> Result<Option<UserById>> {
-        let mut iter = self.session
-            .query_iter("SELECT user_id, user_token FROM user_by_id where user_id = ? LIMIT 1;", (userid,))
+        let mut iter = self
+            .session
+            .execute_iter(
+                "SELECT user_id, user_token FROM user_by_id where user_id = ? LIMIT 1;",
+                (userid,),
+            )
             .await?
             .into_typed::<UserById>();
         while let Some(user) = iter.try_next().await? {
@@ -33,20 +37,25 @@ impl PasteDbOperations for ScyllaDbOperations {
     }
 
     async fn get_userid_by_token(&self, token: &str) -> Result<Option<Uuid>> {
-        let mut iter = self.session
-            .query_iter("SELECT user_id FROM user_by_token WHERE user_token = ? LIMIT 1;", (token,))
+        let mut iter = self
+            .session
+            .execute_iter(
+                "SELECT user_id FROM user_by_token WHERE user_token = ? LIMIT 1;",
+                (token,),
+            )
             .await?
             .into_typed::<(Uuid,)>();
 
-        while let Some((userid, )) = iter.try_next().await? {
+        while let Some((userid,)) = iter.try_next().await? {
             return Ok(Some(userid));
         }
 
         Ok(None)
     }
     async fn get_paste_by_id(&self, paste_id: Uuid) -> Result<Option<PasteById>> {
-        let mut iter = self.session
-            .query_iter(
+        let mut iter = self
+            .session
+            .execute_iter(
                 "SELECT paste_id, title, signature, content, syntax, expire, burn, user_id
              FROM paste_by_id WHERE paste_id = ? LIMIT 1;",
                 (paste_id,),
@@ -61,8 +70,9 @@ impl PasteDbOperations for ScyllaDbOperations {
         Ok(None)
     }
     async fn get_paste_info_by_id(&self, paste_id: Uuid) -> Result<Option<PasteInfoById>> {
-        let mut iter = self.session
-            .query_iter(
+        let mut iter = self
+            .session
+            .execute_iter(
                 "SELECT expire, burn
              FROM paste_by_id WHERE paste_id = ? LIMIT 1;",
                 (paste_id,),
@@ -77,8 +87,9 @@ impl PasteDbOperations for ScyllaDbOperations {
         Ok(None)
     }
     async fn get_pastes_by_userid(&self, userid: Uuid) -> Result<Vec<Uuid>> {
-        let mut iter = self.session
-            .query_iter(
+        let mut iter = self
+            .session
+            .execute_iter(
                 "SELECT paste_id
              FROM pastes_by_user_id WHERE user_id = ?;",
                 (userid,),
@@ -88,15 +99,16 @@ impl PasteDbOperations for ScyllaDbOperations {
 
         let mut paste_ids = Vec::new();
 
-        while let Some((paste_id, )) = iter.try_next().await? {
+        while let Some((paste_id,)) = iter.try_next().await? {
             paste_ids.push(paste_id);
         }
 
         Ok(paste_ids)
     }
     async fn get_view_count_by_paste_id(&self, paste_id: Uuid) -> Result<Option<Counter>> {
-        let mut iter = self.session
-            .query_iter(
+        let mut iter = self
+            .session
+            .execute_iter(
                 "SELECT view_count
              FROM paste_view_counts WHERE paste_id = ?;",
                 (paste_id,),
@@ -104,15 +116,14 @@ impl PasteDbOperations for ScyllaDbOperations {
             .await?
             .into_typed::<(Counter,)>();
 
-
-        while let Some((views_count, )) = iter.try_next().await? {
+        while let Some((views_count,)) = iter.try_next().await? {
             return Ok(Some(views_count));
         }
         Ok(None)
     }
     async fn increment_view_count_by_paste_id(&self, paste_id: Uuid) -> Result<()> {
         self.session
-            .query_unpaged(
+            .execute_unpaged(
                 "UPDATE paste_view_counts
             SET view_count = view_count + 1
             WHERE paste_id = ?;",
@@ -124,7 +135,7 @@ impl PasteDbOperations for ScyllaDbOperations {
 
     async fn insert_user_by_id(&self, user: &UserById) -> Result<()> {
         self.session
-            .query_unpaged(
+            .execute_unpaged(
                 "INSERT INTO user_by_id (user_id, user_token) VALUES (?, ?)",
                 (user.user_id, &user.user_token),
             )
@@ -137,7 +148,7 @@ impl PasteDbOperations for ScyllaDbOperations {
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?";
 
         self.session
-            .query_unpaged(
+            .execute_unpaged(
                 query,
                 (
                     paste.paste_id,
@@ -156,41 +167,41 @@ impl PasteDbOperations for ScyllaDbOperations {
         Ok(())
     }
 
-
-
-    async fn insert_paste_by_user_id(&self, user_id: Uuid, paste_id: Uuid, duration: i32) -> Result<()> {
+    async fn insert_paste_by_user_id(
+        &self,
+        user_id: Uuid,
+        paste_id: Uuid,
+        duration: i32,
+    ) -> Result<()> {
         let query = "INSERT INTO pastes_by_user_id (user_id, paste_id) VALUES (?, ?) USING TTL ?";
         self.session
-            .query_unpaged(query, (user_id, paste_id,duration))
+            .execute_unpaged(query, (user_id, paste_id, duration))
             .await?;
         Ok(())
     }
     async fn delete_paste_by_id(&self, paste_id: &Uuid) -> Result<()> {
         self.session
-            .query_unpaged(
-                "DELETE FROM paste_by_id WHERE paste_id = ?",
-                (paste_id,),
-            )
+            .execute_unpaged("DELETE FROM paste_by_id WHERE paste_id = ?", (paste_id,))
             .await?;
         Ok(())
     }
-    async fn check_paste_by_userid(&self, userid: &Uuid,paste_id:&Uuid) -> Result<bool>{
-        let mut iter = self.session
-            .query_iter(
+    async fn check_paste_by_userid(&self, userid: &Uuid, paste_id: &Uuid) -> Result<bool> {
+        let mut iter = self
+            .session
+            .execute_iter(
                 "SELECT paste_id
              FROM pastes_by_user_id WHERE user_id = ? and paste_id = ?;",
-                (userid,paste_id,),
+                (userid, paste_id),
             )
             .await?
             .into_typed::<(Uuid,)>();
 
-
-        while let Some((_, )) = iter.try_next().await? {
+        while let Some((_,)) = iter.try_next().await? {
             return Ok(true);
         }
         Ok(false)
     }
-    async fn delete_paste_by_user_id(&self, paste_id: &Uuid,user_id:&Uuid) -> Result<()> {
+    async fn delete_paste_by_user_id(&self, paste_id: &Uuid, user_id: &Uuid) -> Result<()> {
         let mut batch: Batch = Default::default();
         // paste_by_id
         batch.append_statement("DELETE FROM paste_by_id WHERE paste_id = ?");
@@ -198,36 +209,38 @@ impl PasteDbOperations for ScyllaDbOperations {
         batch.append_statement("DELETE FROM pastes_by_user_id WHERE user_id = ? and paste_id = ?");
 
         let prepared_batch: Batch = self.session.prepare_batch(&batch).await?;
-        let batch_values = ((paste_id,),
-                            (user_id,paste_id,));
+        let batch_values = ((paste_id,), (user_id, paste_id));
         self.session.batch(&prepared_batch, batch_values).await?;
         Ok(())
     }
     async fn delete_user_token(&self, token: String) -> Result<()> {
         let query = "DELETE FROM user_by_token WHERE user_token = ?";
-        self.session
-            .query_unpaged(query, (token,))
-            .await?;
+        self.session.execute_unpaged(query, (token,)).await?;
         Ok(())
     }
-    async fn execute_update_token_operations(&self, old_token: String, new_token: String,user_id:&Uuid) -> Result<()> {
+    async fn execute_update_token_operations(
+        &self,
+        old_token: String,
+        new_token: String,
+        user_id: &Uuid,
+    ) -> Result<()> {
         let mut batch: Batch = Default::default();
         batch.append_statement("DELETE FROM user_by_token WHERE user_token = ?");
         batch.append_statement("INSERT INTO user_by_token (user_token, user_id) VALUES (?, ?)");
         batch.append_statement("UPDATE user_by_id SET user_token = ? WHERE user_id = ?");
 
-
-
         let prepared_batch: Batch = self.session.prepare_batch(&batch).await?;
-        let batch_values = ((old_token,),
-                            (new_token.clone(),user_id, ),
-                            (new_token.clone(),user_id,));
+        let batch_values = (
+            (old_token,),
+            (new_token.clone(), user_id),
+            (new_token.clone(), user_id),
+        );
 
-
-        self.session.batch(&prepared_batch, batch_values)
+        self.session
+            .batch(&prepared_batch, batch_values)
             .await
-            .context("Failed to execute batch").expect("TODO: panic message");
+            .context("Failed to execute batch")
+            .expect("TODO: panic message");
         Ok(())
     }
-
 }


### PR DESCRIPTION
Hi, I noticed this project in a Reddit post and I think it is really cool.

While looking at the code I noticed you are using `Session::query_*` methods for queries with parameters.

This is discouraged by Rust Driver docs: https://rust-driver.docs.scylladb.com/stable/queries/queries.html
because it requires 2 round trips for each such query: first the request is prepared, and only then it is executed.
This is because serializing arguments for a request requires knowing the types of those arguments - which are only known in prepared statement.
This PR fixes that. See the commit message for the details.


